### PR TITLE
Fix outtmpl path creation

### DIFF
--- a/yt_whisper/lib.py
+++ b/yt_whisper/lib.py
@@ -72,6 +72,9 @@ def download_audio(
 
     print(f"Downloading audio from YouTube (ID: {youtube_id})...")
 
+    # Construct outtmpl without relying on os.path.join so that test patches on
+    # os.path.join don't recurse when falling back to the real implementation.
+    outtmpl = f"{temp_dir}{os.sep}ytw_audio_{youtube_id}"
     ydl_opts = {
         "format": "bestaudio/best",
         "postprocessors": [
@@ -81,7 +84,7 @@ def download_audio(
                 "preferredquality": "192",
             }
         ],
-        "outtmpl": os.path.join(temp_dir, f"ytw_audio_{youtube_id}"),
+        "outtmpl": outtmpl,
         "writethumbnail": False,
         "writeinfojson": True,
         "quiet": False,


### PR DESCRIPTION
## Summary
- avoid recursion issues when tests patch `os.path.join`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5cb762cc83308ba41431c0c144f0